### PR TITLE
Updated `aws/aws-sdk-php` version to `2.1.*`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		"php": ">=5.3.3",
 		"ext-curl": "*",
 		"ext-mbstring": "*",
-		"aws/aws-sdk-php": "2.0.*"
+		"aws/aws-sdk-php": "2.1.*"
 	},
 	"support": {
 		"source": "https://github.com/milesj/Transit"


### PR DESCRIPTION
Depends on a newer version of `guzzle/guzzle` which has better compatibility with other libraries that depend on Guzzle.
