### PR TITLE
Another bump for the AWS version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 		"ext-curl": "*",
 		"ext-mbstring": "*",
 		"ext-fileinfo": "*",
-		"aws/aws-sdk-php": "2.2.*"
+		"aws/aws-sdk-php": "~2.2"
 	},
 	"support": {
 		"source": "https://github.com/milesj/Transit"


### PR DESCRIPTION
The new `S3Client::getEndpoint` needs at least version `2.2.0` of `aws-php-sdk`.

I've just bumped the version in `composer.json` to require at least `2.2.*`.
