### PR TITLE
Fixed ext() method in File.php to call $file->path() instead $this->_path

### DIFF
--- a/src/Transit/File.php
+++ b/src/Transit/File.php
@@ -126,7 +126,7 @@ class File {
 			$ext = MimeType::getExtFromType($file->type(), true);
 
 			if (!$ext) {
-				$ext = mb_strtolower(pathinfo($this->_path, PATHINFO_EXTENSION));
+				$ext = mb_strtolower(pathinfo($file->path(), PATHINFO_EXTENSION));
 			}
 
 			return $ext;


### PR DESCRIPTION
Fixed ext() method in File.php to call $file->path() instead $this->_path
