### PR TITLE
Handle errors from imagecreatefrom* functions where the extension does n...

### DIFF
--- a/src/Transit/Transformer/Image/AbstractImageTransformer.php
+++ b/src/Transit/Transformer/Image/AbstractImageTransformer.php
@@ -49,19 +49,23 @@ abstract class AbstractImageTransformer extends AbstractTransformer {
 		// Create an image to work with
 		switch ($mimeType) {
 			case 'image/gif':
-				$sourceImage = imagecreatefromgif($sourcePath);
+				$sourceImage = @imagecreatefromgif($sourcePath);
 			break;
 			case 'image/png':
-				$sourceImage = imagecreatefrompng($sourcePath);
+				$sourceImage = @imagecreatefrompng($sourcePath);
 			break;
 			case 'image/jpg':
 			case 'image/jpeg':
 			case 'image/pjpeg':
-				$sourceImage = imagecreatefromjpeg($sourcePath);
+				$sourceImage = @imagecreatefromjpeg($sourcePath);
 			break;
 			default:
-				throw new DomainException(sprintf('%s can not be transformed', $mimeType));
+				$sourceImage = false;
 			break;
+		}
+
+		if (!$sourceImage) {
+			throw new DomainException(sprintf('%s can not be transformed', $mimeType));
 		}
 
 		// Gather options


### PR DESCRIPTION
...ot match the file mimeType

I've attempted to upload a JPG with a PNG extension using the Uploader CakePHP plugin and the the following error message:

```
imagecreatefrompng(): 'xxx.png' is not a valid PNG file [APP/Vendor/mjohnson/transit/src/Transit/Transformer/Image/AbstractImageTransformer.php, line 55]
```

This is my attempt at handling that.
