### PR TITLE
Added support for EXIF lat/lng

### DIFF
--- a/src/Transit/File.php
+++ b/src/Transit/File.php
@@ -181,7 +181,10 @@ class File {
                 'fnumber' => 'FNumber',
                 'date' => 'DateTime',
                 'iso' => 'ISOSpeedRatings',
-                'focal' => 'FocalLength'
+                'focal' => 'FocalLength',
+				'latitude' => 'GPSLatitude',
+				'longitude' => 'GPSLongitude',
+				
             );
 
             if ($file->supportsExif()) {
@@ -190,7 +193,11 @@ class File {
                         $value = '';
 
                         if (!empty($data[$find])) {
-                            $value = $data[$find];
+							if ($key == 'latitude' || $key == 'longitude'){
+								$value = $file->dmstodec($data[$find][0], $data[$find][1], $data[$find][2]);
+							} else {
+								$value = $data[$find];
+							}
                         }
 
                         $exif[$key] = $value;
@@ -591,6 +598,17 @@ class File {
     public function toString() {
         return $this->path();
     }
+	
+	/**
+     * Converts DMS ( Degrees / minutes / seconds ) 
+     * to decimal format longitude / latitude
+     * @return float
+     */
+	function dmstodec($deg,$min,$sec) {
+
+		return $deg+((($min*60)+($sec))/3600);
+	
+	}
 
     /**
      * Cache the results of a callback.

--- a/src/Transit/File.php
+++ b/src/Transit/File.php
@@ -182,9 +182,8 @@ class File {
                 'date' => 'DateTime',
                 'iso' => 'ISOSpeedRatings',
                 'focal' => 'FocalLength',
-				'latitude' => 'GPSLatitude',
-				'longitude' => 'GPSLongitude',
-				
+		'latitude' => 'GPSLatitude',
+		'longitude' => 'GPSLongitude'
             );
 
             if ($file->supportsExif()) {

--- a/src/Transit/File.php
+++ b/src/Transit/File.php
@@ -193,11 +193,11 @@ class File {
                         $value = '';
 
                         if (!empty($data[$find])) {
-							if ($key == 'latitude' || $key == 'longitude'){
-								$value = $file->dmstodec($data[$find][0], $data[$find][1], $data[$find][2]);
-							} else {
-								$value = $data[$find];
-							}
+				if ($key == 'latitude' || $key == 'longitude'){
+					$value = $file->dmstodec($data[$find][0], $data[$find][1], $data[$find][2]);
+				} else {
+					$value = $data[$find];
+				}
                         }
 
                         $exif[$key] = $value;


### PR DESCRIPTION
I needed support for my web app to pull lat/lng data from uploaded images, so here you go.

This patch adds two new metadata fields: ```latitude``` and ```longitude```.

EXIF lat/lng data is stored as an array of DMS values, not decimal, so this also adds a new function ```dmstodec()``` which converts this array into a decimal value you can easily store in a database.